### PR TITLE
Fix sbartlett/homebridge-wink3#106 Offline Devices Not Showing as No Response

### DIFF
--- a/src/AccessoryHelper.js
+++ b/src/AccessoryHelper.js
@@ -103,7 +103,10 @@ module.exports = class AccessoryHelper {
     // First argument is current state
     // Second argument is desired state (merged state)
     const value = get(accessory.context.last_reading, accessory.merged_state);
-    callback(null, value);
+    if (accessory.context.last_reading.connection)
+       callback(null, value);
+    else
+       callback("no_response");
   }
 
   writeAccessory(accessory, set, value, callback) {


### PR DESCRIPTION
From sbartlett/homebridge-wink3:#120

The fix suggested by @mriksman worked correctly for me as well. See attached PR. Online devices still functioning normally, but bulbs that are offline now show NO RESPONSE. Before I applied this update locally, bulbs that were offline would show ON (100% Brightness).